### PR TITLE
Increase requests package from 2.21.0 to 2.24.0 to allow compatibility with boto3 requirements for urllib3 > 1.25.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from setuptools import setup, find_packages
 
 DEPENDENCIES = [
-    'requests==2.21.0',
+    'requests==2.24.0',
     'cryptography==2.6.1',
 ]
 


### PR DESCRIPTION
See Issue https://github.com/wlwg/aws-sns-message-validator/issues/4

boto3 v1.16.12 requires urllib3 [required: >=1.25.4,<1.26, ...]

requests 2.21.0 requires urllib3 [required: >=1.21.1,<1.25, ...]

This creates a dependency conflict. Bumping requests to 2.24.0 allows urllib3 [required: >=1.21.1,<1.26,!=1.25.1,!=1.25.0...], and thus urllib3==1.25.11 will satisfy both boto3 and aws-sns-message-validator.