### PR TITLE
cache signing certificate to reduce load with high transactionality

### DIFF
--- a/flask_example.py
+++ b/flask_example.py
@@ -14,11 +14,11 @@ from sns_message_validator import (
 
 
 APP = Flask(__name__)
+sns_message_validator = SNSMessageValidator()
 
 @APP.route('/', methods=['POST'])
 def main():
     logger = logging.getLogger('view.main')
-    sns_message_validator = SNSMessageValidator()
 
     # Validate message type from header without having to parse the request body.
     message_type = request.headers.get('x-amz-sns-message-type')

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@ from setuptools import setup, find_packages
 
 DEPENDENCIES = [
     'requests>=2.24.0',
+    'requests-cache>=0.8.0'
     'cryptography>=3.3.2',
 ]
 

--- a/sns_message_validator/sns_message_validator.py
+++ b/sns_message_validator/sns_message_validator.py
@@ -1,6 +1,6 @@
 import re
 import base64
-import requests
+from requests_cache import CachedSession
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.asymmetric.padding import PKCS1v15
@@ -24,6 +24,7 @@ class SNSMessageValidator:
                  signature_version='1'):
         self._cert_url_regex = cert_url_regex
         self._signature_version = signature_version
+        self.certSession = CachedSession('cert_cache', backend='memory')
 
     def _validate_signature_version(self, message):
         if message.get('SignatureVersion') != self._signature_version:
@@ -51,7 +52,7 @@ class SNSMessageValidator:
 
     def _verify_signature(self, message):
         try:
-            pem = requests.get(message.get('SigningCertURL')).content
+            pem = self.certSession.get(message.get('SigningCertURL')).content
         except Exception:
             raise SignatureVerificationFailureException('Failed to fetch cert file.')
 

--- a/sns_message_validator/sns_message_validator.py
+++ b/sns_message_validator/sns_message_validator.py
@@ -24,7 +24,7 @@ class SNSMessageValidator:
                  signature_version='1'):
         self._cert_url_regex = cert_url_regex
         self._signature_version = signature_version
-        self.certSession = CachedSession('cert_cache', backend='memory')
+        self._cert_session = CachedSession('cert_cache', backend='memory')
 
     def _validate_signature_version(self, message):
         if message.get('SignatureVersion') != self._signature_version:
@@ -52,7 +52,7 @@ class SNSMessageValidator:
 
     def _verify_signature(self, message):
         try:
-            pem = self.certSession.get(message.get('SigningCertURL')).content
+            pem = self._cert_session.get(message.get('SigningCertURL')).content
         except Exception:
             raise SignatureVerificationFailureException('Failed to fetch cert file.')
 


### PR DESCRIPTION
This PR adds a dependency to requests-cache and transparently caches the signing cert in memory. If the signing cert changes, it will have a different URL, so the new one will get downloaded.

The example app is updated to put the validator object in global scope so it doesn't get recreated on every notification.

Resolves #11 