### PR TITLE
fix missing comma in dependencies list

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ LONG_DESCRIPTION = (Path(__file__).parent/'README.md').read_text()
 
 DEPENDENCIES = [
     'requests>=2.24.0',
-    'requests-cache>=0.8.0'
+    'requests-cache>=0.8.0',
     'cryptography>=3.3.2',
 ]
 


### PR DESCRIPTION
There is a missing comma in the dependencies list which causes installation of the package to fail. This is because pip will be trying to fetch a package `requests-cache>=0.8.0cryptography>=3.3.2`. 

This PR adds the missing comma. 