### PR TITLE
Remove `requests-cache` dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,6 @@ LONG_DESCRIPTION = (Path(__file__).parent/'README.md').read_text()
 
 DEPENDENCIES = [
     'requests>=2.24.0',
-    'requests-cache>=0.8.0',
     'cryptography>=3.3.2',
 ]
 


### PR DESCRIPTION
#12 added caching using `requests-cache`.  `requests-cache` is a powerful library with half a dozen dependencies, but we're only utilizing its most basic functionality.

This PR removes `requests-cache` as a dependency, instead using stdlib's `lru_cache` and vanilla `requests` to achieve the same effect.